### PR TITLE
Feat/screenshots functionality

### DIFF
--- a/src/components/ImageInfo/ImageInfo.tsx
+++ b/src/components/ImageInfo/ImageInfo.tsx
@@ -37,13 +37,13 @@ export const ImageInfo = () => {
 const styles = (theme: Theme) => ({
   footerWrapper: {
     position: "absolute",
-    right: 0,
-    bottom: 0,
+    right: 55,
+    bottom: 6,
     display: "flex",
     gap: "8px",
     backgroundColor: alpha(theme.palette.gx.primary.black, 0.5),
-    padding: "8px 20px 10px",
-    borderTopLeftRadius: "16px",
+    padding: "8px 14px 10px",
+    borderRadius: "10px",
   },
   footerText: {
     color: theme.palette.gx.primary.white,

--- a/src/components/PictureInPictureViewerAdapter/PictureInPictureViewerAdapter.tsx
+++ b/src/components/PictureInPictureViewerAdapter/PictureInPictureViewerAdapter.tsx
@@ -9,17 +9,25 @@ import { useChannelsStore } from "../../stores/ChannelsStore/ChannelsStore";
 import { useShallow } from "zustand/react/shallow";
 import { DEFAULT_OVERVIEW, FILL_PIXEL_VALUE } from "../../shared/constants";
 import { useViewerStore } from "../../stores/ViewerStore/ViewerStore";
-import { Box } from "@mui/material";
+import {
+  alpha,
+  Box,
+  IconButton,
+  Tooltip as MuiTooltip,
+  Theme,
+  useTheme,
+} from "@mui/material";
 import {
   useCellSegmentationLayer,
   useTranscriptLayer,
   useResizableContainer,
   useHEImageLayer,
 } from "./PictureInPictureViewerAdapter.hooks";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Tooltip } from "../Tooltip";
 import { debounce } from "lodash";
 import { useHEImageStore } from "../../stores/HEImageStore";
+import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
 
 export const PictureInPictureViewerAdapter = () => {
   const getLoader = useChannelsStore((store) => store.getLoader);
@@ -31,6 +39,10 @@ export const PictureInPictureViewerAdapter = () => {
   const cellMasksLayer = useCellSegmentationLayer();
   const transcriptLayer = useTranscriptLayer();
   const heImageLayer = useHEImageLayer();
+  const deckGLRef = useRef<any>(null);
+
+  const theme = useTheme();
+  const sx = styles(theme);
 
   useEffect(
     () =>
@@ -85,8 +97,31 @@ export const PictureInPictureViewerAdapter = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loader, containerSize.width, containerSize.height]);
 
+  const takeScreenshot = () => {
+    if (deckGLRef.current && deckGLRef.current.deck) {
+      const canvas = deckGLRef.current.deck.canvas;
+      if (canvas) {
+        const result = canvas.toDataURL("image/png");
+
+        const link = document.createElement("a");
+        link.href = result;
+        link.download = `screenshot-${new Date()
+          .toISOString()
+          .slice(0, 19)
+          .replace(/:/g, "-")}.png`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+    }
+  };
+
   const deckProps = {
     layers: [cellMasksLayer, transcriptLayer],
+    ref: deckGLRef,
+    glOptions: {
+      preserveDrawingBuffer: true,
+    },
   };
 
   if (heImageSource && !isImageLoading) {
@@ -96,70 +131,92 @@ export const PictureInPictureViewerAdapter = () => {
   return (
     <Box sx={sx.viewerContainer} ref={containerRef}>
       {containerSize.width && containerSize.height && (
-        <PictureInPictureViewer
-          contrastLimits={contrastLimits}
-          colors={colors}
-          channelsVisible={channelsVisible}
-          loader={loader}
-          selections={selections}
-          overview={DEFAULT_OVERVIEW}
-          overviewOn={isOverviewOn}
-          height={containerSize.height}
-          width={containerSize.width}
-          extensions={[
-            colormap ? new AdditiveColormapExtension() : new LensExtension(),
-          ]}
-          lensSelection={lensSelection}
-          lensEnabled={isLensOn}
-          deckProps={deckProps}
-          colormap={colormap}
-          onViewportLoad={onViewportLoad}
-          viewStates={viewState ? [viewState] : []}
-          onViewStateChange={debounce(
-            ({ viewState: newViewState, viewId }) => {
-              const z = Math.min(
-                Math.max(Math.round(-(newViewState as any).zoom), 0),
-                loader.length - 1
-              );
-              useViewerStore.setState({
-                pyramidResolution: z,
-                viewState: { ...newViewState, id: viewId },
-              });
-            },
-            250,
-            { trailing: true }
-          )}
-          hoverHooks={{
-            handleValue: (values) =>
-              useViewerStore.setState({
-                pixelValues: values.map((value) =>
-                  Number.isInteger(value)
-                    ? value.toFixed(1).toString()
-                    : FILL_PIXEL_VALUE
-                ),
-              }),
-            // @ts-expect-error Error in Viv jsDOC declaration.
-            // TODO: Fix when issue has beeen resolved and new version has been released.
-            handleCoordnate: (coords: number[]) =>
-              coords &&
-              useViewerStore.setState({
-                hoverCoordinates: {
-                  x: coords[0].toFixed(0).toString(),
-                  y: coords[1].toFixed(0).toString(),
-                },
-              }),
-          }}
-        />
+        <>
+          <PictureInPictureViewer
+            contrastLimits={contrastLimits}
+            colors={colors}
+            channelsVisible={channelsVisible}
+            loader={loader}
+            selections={selections}
+            overview={DEFAULT_OVERVIEW}
+            overviewOn={isOverviewOn}
+            height={containerSize.height}
+            width={containerSize.width}
+            extensions={[
+              colormap ? new AdditiveColormapExtension() : new LensExtension(),
+            ]}
+            lensSelection={lensSelection}
+            lensEnabled={isLensOn}
+            deckProps={deckProps}
+            colormap={colormap}
+            onViewportLoad={onViewportLoad}
+            viewStates={viewState ? [viewState] : []}
+            onViewStateChange={debounce(
+              ({ viewState: newViewState, viewId }) => {
+                const z = Math.min(
+                  Math.max(Math.round(-(newViewState as any).zoom), 0),
+                  loader.length - 1
+                );
+                useViewerStore.setState({
+                  pyramidResolution: z,
+                  viewState: { ...newViewState, id: viewId },
+                });
+              },
+              250,
+              { trailing: true }
+            )}
+            hoverHooks={{
+              handleValue: (values) =>
+                useViewerStore.setState({
+                  pixelValues: values.map((value) =>
+                    Number.isInteger(value)
+                      ? value.toFixed(1).toString()
+                      : FILL_PIXEL_VALUE
+                  ),
+                }),
+              // @ts-expect-error Error in Viv jsDOC declaration.
+              // TODO: Fix when issue has beeen resolved and new version has been released.
+              handleCoordnate: (coords: number[]) =>
+                coords &&
+                useViewerStore.setState({
+                  hoverCoordinates: {
+                    x: coords[0].toFixed(0).toString(),
+                    y: coords[1].toFixed(0).toString(),
+                  },
+                }),
+            }}
+          />
+          <MuiTooltip title="Screenshot">
+            <IconButton
+              sx={sx.screenshotButton}
+              onClick={takeScreenshot}
+              color="primary"
+            >
+              <PhotoCameraIcon />
+            </IconButton>
+          </MuiTooltip>
+        </>
       )}
       <Tooltip />
     </Box>
   );
 };
 
-const sx = {
+const styles = (theme: Theme) => ({
   viewerContainer: {
     position: "relative",
     width: "100%",
     height: "100%",
   },
-};
+  screenshotButton: {
+    position: "absolute",
+    bottom: 8,
+    right: 8,
+    zIndex: 100,
+    color: theme.palette.gx.lightGrey[300],
+    backgroundColor: alpha(theme.palette.gx.primary.black, 0.5),
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.gx.darkGrey[700], 0.5),
+    },
+  },
+});


### PR DESCRIPTION
## Description

Added screenshots functionality

Setting `preserveDrawingBuffer: true` is essential for capturing screenshots from WebGL canvases like DeckGL, as it preserves the rendered content that would otherwise be cleared after rendering, it may slightly impact performance due to increased memory usage.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Load image
2. Click screenshot icon in the right bottom corner
