### PR TITLE
Fix/bright fields images persistance switching

### DIFF
--- a/src/components/PictureInPictureViewerAdapter/PictureInPictureViewerAdapter.hooks.ts
+++ b/src/components/PictureInPictureViewerAdapter/PictureInPictureViewerAdapter.hooks.ts
@@ -152,11 +152,12 @@ export const useBrightfieldImageLayer = () => {
   );
 
   const loader = getLoader();
-  const { dtype } = loader[0];
 
-  if (!loader) {
+  if (!loader || !loader[0] || !loader[0].shape) {
     return undefined;
   }
+
+  const { dtype } = loader[0];
 
   const brightfieldImageLayer = new MultiscaleImageLayer({
     id: `${getVivId(DETAIL_VIEW_ID)}-h&e-image-layer`,

--- a/src/hooks/useBrightfieldImage.hook.ts
+++ b/src/hooks/useBrightfieldImage.hook.ts
@@ -10,6 +10,9 @@ export const useBrightfieldImage = (source: ViewerSourceType | null) => {
   const loader = useBrightfieldImagesStore.getState().getLoader();
 
   useEffect(() => {
+    // Reset state when source changes
+    setIsLoaderCreated(false);
+
     async function changeLoader() {
       if (!source) return null;
 
@@ -42,8 +45,17 @@ export const useBrightfieldImage = (source: ViewerSourceType | null) => {
         setIsLoaderCreated(true);
       }
     }
-    if (source) changeLoader();
-  }, [source, history]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    if (source) {
+      changeLoader();
+    } else {
+      // Reset loader state when source is null
+      useBrightfieldImagesStore.setState({
+        loader: [{ labels: [], shape: [] }],
+        isImageLoading: false
+      });
+    }
+  }, [source]);
 
   useEffect(() => {
     if (!source || !isLoaderCreated) return;

--- a/src/stores/BrightfieldImagesStore/BrightfieldImagesStore.ts
+++ b/src/stores/BrightfieldImagesStore/BrightfieldImagesStore.ts
@@ -23,15 +23,23 @@ export const useBrightfieldImagesStore = create<BrightfieldImagesStore>((set, ge
     return Array.isArray(loader[0]) ? loader[image] : loader;
   },
   toggleImageLayer: () => set((store) => ({ isLayerVisible: !store.isLayerVisible })),
-  setActiveImage: (file: File | string | null) =>
+  setActiveImage: (file: File | string | null) => {
+    if (file === null) {
+      set({
+        brightfieldImageSource: null,
+        loader: DEFAULT_VALUES.loader
+      });
+      return;
+    }
+
     set({
-      brightfieldImageSource: file
-        ? {
-            description: typeof file === 'string' ? file.split('/').pop() || file : file.name,
-            urlOrFile: file
-          }
-        : null
-    }),
+      brightfieldImageSource: {
+        description: typeof file === 'string' ? file.split('/').pop() || file : file.name,
+        urlOrFile: file
+      },
+      loader: DEFAULT_VALUES.loader
+    });
+  },
   setAvailableImages: (files: (File | string)[]) => set({ availableImages: files }),
   addNewFile: (file: File | string) =>
     set((state) => {


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: #47

## Description

Fixes an issue where switching between two HE image sources causes the previously selected image to appear.
For more details, refer to the linked issue ticket.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Upload any acceptable OME-Tiff file
2. Upload at least two easily distinguishable H&E images in the "Brightfield Images Section"
3. Select one of the H&E Images
4. Diselect the current option and select other H&E image
