### PR TITLE
Prevent overflow x axis segmentation section

### DIFF
--- a/src/shared/components/GxFilterTable/GxFilterTable.tsx
+++ b/src/shared/components/GxFilterTable/GxFilterTable.tsx
@@ -74,7 +74,7 @@ export const GxFilterTable = <T extends GxFilterTableRowPropBase>({
       </Box>
       <FormControlLabel
         label="Show active filters only"
-        labelPlacement="start"
+        labelPlacement="end"
         sx={sx.activeFiltersSwitchWrapper}
         control={
           <GxCheckbox


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #38

## Description

Prevented overflow x axis in the segmentation settings section

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Upload any acceptable OME-Tiff file
2. Upload a Segmentation data .bin file
3. Expand Segmentation Layer Settings section in the controller
