### PR TITLE
Fix/cell mask layer toggle

### DIFF
--- a/src/layers/cell-masks-layer/cell-masks-layer.ts
+++ b/src/layers/cell-masks-layer/cell-masks-layer.ts
@@ -63,7 +63,7 @@ class CellMasksLayer extends CompositeLayer<CellMasksLayerProps> {
         getFillColor: this.props.cellFillOpacity
       },
       getLineWidth: 0,
-      visible: this.props.showDiscardedPoints
+      visible: this.props.visible && this.props.showDiscardedPoints
     });
 
     const polygonLayer = new PolygonLayer({
@@ -79,7 +79,8 @@ class CellMasksLayer extends CompositeLayer<CellMasksLayerProps> {
         getFillColor: this.props.cellFillOpacity
       },
       getLineWidth: 0,
-      pickable: true
+      pickable: true,
+      visible: this.props.visible
     });
 
     return [outliersPolygonLayer, polygonLayer];


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #67

## Description

Fixed an issue where the 'Cell Mask' checkbox didn’t toggle layer visibility

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Load Cell Mask file
2. Toggle View Settings -> Cell Mask checkbox
