### PR TITLE
Fix/Drag-and-drop Bin file Upload issue

### DIFF
--- a/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/helpers/useCellMasksFileHandler.tsx
+++ b/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/helpers/useCellMasksFileHandler.tsx
@@ -58,7 +58,7 @@ export const useCellMasksFileHandler = () => {
       });
       useCytometryGraphStore.getState().resetFilters();
     };
-    reader.onerror = () => console.error('Something went wrong during file laod!');
+    reader.onerror = () => console.error('Something went wrong during file load!');
     reader.readAsArrayBuffer(files[0]);
     reader.addEventListener('progress', (event: ProgressEvent<FileReader>) =>
       setProgress(Math.round((event.loaded / event.total) * 100))
@@ -74,7 +74,11 @@ export const useCellMasksFileHandler = () => {
     onDrop,
     multiple: false,
     accept: {
-      'application/octet-stream': ['.bin']
+      'application/octet-stream': ['.bin'],
+      'application/macbinary': ['.bin'],
+      'application/binary': ['.bin'],
+      '': ['.bin'],
+      '*': ['.bin']
     }
   });
 


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #98

## Description

Fixed issue where the “Drag-and-drop to Upload Cell Mask” button showed “File Type Not Accepted” for valid .bin files.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Drag and drop a .bin file
