### PR TITLE
Fix/Nuclear channel always first

### DIFF
--- a/src/hooks/useProteinImage.hook.ts
+++ b/src/hooks/useProteinImage.hook.ts
@@ -11,6 +11,8 @@ import { isInterleaved } from '@hms-dbmi/viv';
 import { COLOR_PALLETE } from '../shared/constants';
 import { ChannelsSettings } from '../stores/ChannelsStore';
 
+const NUCLEAR_CHANNEL = 'nuclear';
+
 export const useProteinImage = (source: ViewerSourceType | null) => {
   const loader = useChannelsStore.getState().getLoader();
   const metadata = useMetadata();
@@ -68,7 +70,16 @@ export const useProteinImage = (source: ViewerSourceType | null) => {
       useViewerStore.setState({ isViewerLoading: true });
       const newSelections = buildDefaultSelection(loader[0]);
       const { Channels } = metadata.Pixels;
+
       const channelOptions = Channels.map((c: any, i: any) => c.Name ?? `Channel ${i}`);
+      const nuclearIndex = channelOptions.findIndex((name: string) => name.toLowerCase().includes(NUCLEAR_CHANNEL));
+
+      // If nuclear channel found, move it to first position
+      if (nuclearIndex > 0) {
+        const nuclearChannel = channelOptions[nuclearIndex];
+        channelOptions.splice(nuclearIndex, 1);
+        channelOptions.unshift(nuclearChannel);
+      }
       // Default RGB.
       let newContrastLimits = [];
       let newDomains = [];


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #91

## Description

Make nuclear channel always first

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Open app
2. Load ome tiff with nuclear channel
