### PR TITLE
Feat: Add file size upload prevention error banner

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -173,6 +173,7 @@
     "transcriptsUnpackError": "Error unpacking {{file}}",
     "transcriptsUnpackSuccess": "Successfully unpacked",
     "transcriptsUnsupportedError": "File type not supported",
+    "uploadedFileSizeHelper": "Max: {{size}}",
     "uploadedFileSizeError": "Uploaded file exceeds allowed limit of: {{size}}"
   },
   "transcript": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -172,7 +172,8 @@
     "transcriptsMissingColormap": "Missing colormap config, transcript metadata filtering will be unavailable",
     "transcriptsUnpackError": "Error unpacking {{file}}",
     "transcriptsUnpackSuccess": "Successfully unpacked",
-    "transcriptsUnsupportedError": "File type not supported"
+    "transcriptsUnsupportedError": "File type not supported",
+    "uploadedFileSizeError": "Uploaded file exceeds allowed limit of: {{size}}"
   },
   "transcript": {
     "cellId": "Cell ID",

--- a/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/CellMasksDropzoneButton.tsx
+++ b/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/CellMasksDropzoneButton.tsx
@@ -6,6 +6,8 @@ import { useCellSegmentationLayerStore } from '../../../../stores/CellSegmentati
 import { CellMasksDropzoneButtonProps } from './CellMasksDropzoneButton.types';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { humanFileSize } from '../../../../utils/utils';
+import { SEGMENTATION_FILE_SIZE_LIMIT } from '../../../../shared/constants';
 
 export const CellMasksDropzoneButton = ({ setLockSwitch }: CellMasksDropzoneButtonProps) => {
   const theme = useTheme();
@@ -25,6 +27,7 @@ export const CellMasksDropzoneButton = ({ setLockSwitch }: CellMasksDropzoneButt
         labelText={fileName}
         buttonText={t('sourceFiles.segmentationFileUploadButton')}
         disabled={!source}
+        helperText={t('sourceFiles.uploadedFileSizeHelper', { size: humanFileSize(SEGMENTATION_FILE_SIZE_LIMIT, 0) })}
         {...dropzoneProps}
       />
       {loading && (

--- a/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/helpers/useCellMasksFileHandler.tsx
+++ b/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/helpers/useCellMasksFileHandler.tsx
@@ -8,6 +8,8 @@ import { useCytometryGraphStore } from '../../../../../stores/CytometryGraphStor
 import { useTranslation } from 'react-i18next';
 import { usePolygonDrawingStore } from '../../../../../stores/PolygonDrawingStore';
 import { usePolygonDetectionWorker } from '../../../../PictureInPictureViewerAdapter/worker/usePolygonDetectionWorker';
+import { SEGMENTATION_FILE_SIZE_LIMIT } from '../../../../../shared/constants';
+import { humanFileSize } from '../../../../../utils/utils';
 
 export const useCellMasksFileHandler = () => {
   const [progress, setProgress] = useState(0);
@@ -22,6 +24,16 @@ export const useCellMasksFileHandler = () => {
     if (files.length !== 1) {
       return;
     }
+
+    if (files[0].size > SEGMENTATION_FILE_SIZE_LIMIT) {
+      enqueueSnackbar({
+        variant: 'gxSnackbar',
+        titleMode: 'error',
+        message: t('sourceFiles.uploadedFileSizeError', { size: humanFileSize(SEGMENTATION_FILE_SIZE_LIMIT) })
+      });
+    }
+
+    console.log(files[0].size);
     setLoading(true);
     const reader = new FileReader();
     reader.onload = async () => {

--- a/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/helpers/useCellMasksFileHandler.tsx
+++ b/src/components/ViewController/SourceFilesSection/CellMasksDropzoneButton/helpers/useCellMasksFileHandler.tsx
@@ -31,6 +31,7 @@ export const useCellMasksFileHandler = () => {
         titleMode: 'error',
         message: t('sourceFiles.uploadedFileSizeError', { size: humanFileSize(SEGMENTATION_FILE_SIZE_LIMIT) })
       });
+      return;
     }
 
     console.log(files[0].size);

--- a/src/components/ViewController/SourceFilesSection/TranscriptDropzoneButton/TranscriptDropzoneButton.tsx
+++ b/src/components/ViewController/SourceFilesSection/TranscriptDropzoneButton/TranscriptDropzoneButton.tsx
@@ -6,6 +6,8 @@ import { useViewerStore } from '../../../../stores/ViewerStore';
 import { TranscriptDropzoneButtonProps } from './TranscriptDropzoneButton.types';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { humanFileSize } from '../../../../utils/utils';
+import { TRANSCRIPT_FILEZ_SIZE_LIMIT } from '../../../../shared/constants';
 
 export default function TranscriptDropzoneButton({ setLockSwitch }: TranscriptDropzoneButtonProps) {
   const theme = useTheme();
@@ -27,6 +29,7 @@ export default function TranscriptDropzoneButton({ setLockSwitch }: TranscriptDr
         labelText={fileName}
         buttonText={t('sourceFiles.transcriptsFileUploadButton')}
         disabled={!source}
+        helperText={t('sourceFiles.uploadedFileSizeHelper', { size: humanFileSize(TRANSCRIPT_FILEZ_SIZE_LIMIT, 0) })}
         {...dropzoneProps}
       />
       {loading && (

--- a/src/components/ViewController/SourceFilesSection/TranscriptDropzoneButton/helpers/useFileHandler.tsx
+++ b/src/components/ViewController/SourceFilesSection/TranscriptDropzoneButton/helpers/useFileHandler.tsx
@@ -111,6 +111,7 @@ export const useFileHandler = () => {
         titleMode: 'error',
         message: t('sourceFiles.uploadedFileSizeError', { size: humanFileSize(TRANSCRIPT_FILEZ_SIZE_LIMIT) })
       });
+      return;
     }
 
     switch (file.type) {

--- a/src/components/ViewController/SourceFilesSection/TranscriptDropzoneButton/helpers/useFileHandler.tsx
+++ b/src/components/ViewController/SourceFilesSection/TranscriptDropzoneButton/helpers/useFileHandler.tsx
@@ -4,11 +4,12 @@ import { ConfigFileData, useBinaryFilesStore } from '../../../../../stores/Binar
 import { useSnackbar } from 'notistack';
 import ZipWorker from './zipWorker.js?worker';
 import TarWorker from './tarWorker.js?worker';
-import { parseJsonFromFile } from '../../../../../utils/utils';
+import { humanFileSize, parseJsonFromFile } from '../../../../../utils/utils';
 import { useTranscriptLayerStore } from '../../../../../stores/TranscriptLayerStore';
 import { usePolygonDetectionWorker } from '../../../../PictureInPictureViewerAdapter/worker/usePolygonDetectionWorker';
 import { usePolygonDrawingStore } from '../../../../../stores/PolygonDrawingStore';
 import { useTranslation } from 'react-i18next';
+import { TRANSCRIPT_FILEZ_SIZE_LIMIT } from '../../../../../shared/constants';
 
 type WorkerType = typeof ZipWorker | typeof TarWorker;
 
@@ -103,6 +104,14 @@ export const useFileHandler = () => {
 
     setProgress(0);
     const file = acceptedFiles[0];
+
+    if (file.size > TRANSCRIPT_FILEZ_SIZE_LIMIT) {
+      enqueueSnackbar({
+        variant: 'gxSnackbar',
+        titleMode: 'error',
+        message: t('sourceFiles.uploadedFileSizeError', { size: humanFileSize(TRANSCRIPT_FILEZ_SIZE_LIMIT) })
+      });
+    }
 
     switch (file.type) {
       case 'application/zip':

--- a/src/shared/components/GxDropzoneButton/GxDropzoneButton.tsx
+++ b/src/shared/components/GxDropzoneButton/GxDropzoneButton.tsx
@@ -47,21 +47,22 @@ export const GxDropzoneButton = ({
         label={labelTitle}
         size="small"
         fullWidth
-        inputProps={{ readOnly: true }}
         value={labelText || ' '}
         sx={sx.textField}
         disabled={disabled}
-        InputProps={{
-          endAdornment: onCloudUploadClick && (
-            <IconButton
-              onClick={onCloudUploadClick}
-              size="small"
-              sx={isCloudUploaded ? sx.cloudUploadIconActive : sx.cloudUploadIcon}
-              disabled={disabled}
-            >
-              <CloudUploadIcon />
-            </IconButton>
-          )
+        slotProps={{
+          input: {
+            endAdornment: onCloudUploadClick && (
+              <IconButton
+                onClick={onCloudUploadClick}
+                size="small"
+                sx={isCloudUploaded ? sx.cloudUploadIconActive : sx.cloudUploadIcon}
+                disabled={disabled}
+              >
+                <CloudUploadIcon />
+              </IconButton>
+            )
+          }
         }}
       />
       <Button

--- a/src/shared/components/GxDropzoneButton/GxDropzoneButton.tsx
+++ b/src/shared/components/GxDropzoneButton/GxDropzoneButton.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, TextField, Theme, alpha, useTheme, IconButton } from '@mui/material';
+import { Box, Button, TextField, Theme, alpha, useTheme, IconButton, Typography, SxProps } from '@mui/material';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import { GxDropzoneButtonProps } from './GxDropzoneButton.types';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ export const GxDropzoneButton = ({
   getInputProps,
   labelTitle,
   labelText,
+  helperText,
   buttonText,
   disabled = false,
   onCloudUploadClick,
@@ -74,11 +75,12 @@ export const GxDropzoneButton = ({
         <input {...getInputProps()} />
         {dynamicButtonText}
       </Button>
+      {helperText && <Typography sx={sx.dropzoneHelperMessage}>{helperText}</Typography>}
     </Box>
   );
 };
 
-const styles = (theme: Theme) => ({
+const styles = (theme: Theme): Record<string, SxProps> => ({
   textField: {
     marginBottom: '8px',
     '& .MuiFormLabel-root.Mui-focused': {
@@ -104,6 +106,10 @@ const styles = (theme: Theme) => ({
       backgroundColor: alpha(theme.palette.gx.accent.greenBlue, 0.2)
     },
     transition: 'all 0.15s ease'
+  },
+  dropzoneHelperMessage: {
+    fontSize: '12px',
+    color: theme.palette.gx.mediumGrey[100]
   },
   cloudUploadIcon: {
     color: theme.palette.grey[500],

--- a/src/shared/components/GxDropzoneButton/GxDropzoneButton.types.ts
+++ b/src/shared/components/GxDropzoneButton/GxDropzoneButton.types.ts
@@ -5,6 +5,7 @@ export type GxDropzoneButtonProps = {
   getInputProps: <T extends DropzoneInputProps>(props?: T | undefined) => T;
   labelTitle: string;
   labelText?: string;
+  helperText?: string;
   buttonText: string;
   disabled?: boolean;
   onCloudUploadClick?: () => void;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,3 +31,6 @@ export const COLOR_PALLETE = [
 ];
 
 export const FILL_PIXEL_VALUE = '----';
+
+export const SEGMENTATION_FILE_SIZE_LIMIT = 367001600; // 350 MB
+export const TRANSCRIPT_FILEZ_SIZE_LIMIT = 1073741824; // 1 GB

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -61,3 +61,25 @@ export const generatePolygonColor = (index: number): [number, number, number] =>
   // Use modulo to cycle through colors if we have more polygons than predefined colors
   return POLYGON_COLORS[index % POLYGON_COLORS.length];
 };
+
+export const humanFileSize = (bytes: number, si = false, dp = 1) => {
+  const thresh = si ? 1000 : 1024;
+
+  if (Math.abs(bytes) < thresh) {
+    return bytes + ' B';
+  }
+
+  const units = si
+    ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+
+  let u = -1;
+  const r = 10 ** dp;
+
+  do {
+    bytes /= thresh;
+    ++u;
+  } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
+
+  return bytes.toFixed(dp) + ' ' + units[u];
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -62,7 +62,7 @@ export const generatePolygonColor = (index: number): [number, number, number] =>
   return POLYGON_COLORS[index % POLYGON_COLORS.length];
 };
 
-export const humanFileSize = (bytes: number, si = false, dp = 1) => {
+export const humanFileSize = (bytes: number, dp = 1, si = false) => {
   const thresh = si ? 1000 : 1024;
 
   if (Math.abs(bytes) < thresh) {


### PR DESCRIPTION
## Description

* Adds a file size limit to the transcripts and segmentation upload buttons
* Add a helper text prop to the shared GxDropzoneButton component
* Update MUI deprecated props

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Run the application.
2. Upload any valid OME-Tiff 
3. Try to upload either transcripts or a segmentation file exceeding the size limit shown underneath the upload buttonž
