### PR TITLE
Fix/Dashboard ROIs order

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -300,6 +300,7 @@
     "plotValueType": "Modality",
     "plotSwapAxisLabel": "Swap Axis",
     "plotDataModeLabel": "Data Mode",
+    "plotSortRoisLabel": "Sort ROIs",
     "availableROILabel": "Available ROIs",
     "availableGenesLabel": "Available Genes",
     "availableProteinsLabel": "Available Proteins",

--- a/src/components/DashboardCharts/BarChart/BarChart.tsx
+++ b/src/components/DashboardCharts/BarChart/BarChart.tsx
@@ -12,7 +12,8 @@ export const BarChart = ({ id, title, removable = true }: BarChartProps) => {
   const [selectedValueType, setSelectedValueType] = useState<BarChartValueType>('protein');
   const [settings, setSettings] = useState<BarChartSettingOptions>({
     swapAxis: false,
-    barMode: 'group'
+    barMode: 'group',
+    sortRois: false
   });
 
   return (

--- a/src/components/DashboardCharts/BarChart/sections/BarChartPlot/BarChartPlot.helpers.ts
+++ b/src/components/DashboardCharts/BarChart/sections/BarChartPlot/BarChartPlot.helpers.ts
@@ -24,7 +24,8 @@ export function useBarChartPlotDataParser() {
       valueType: BarChartValueType,
       selectedvalue: string,
       hueValue: BarChartHueValueOptions,
-      orientation: BarChartOrientation
+      orientation: BarChartOrientation,
+      sortRois: boolean
     ): BarChartDataEntry[] => {
       if (!selectedCells.length || !segmentationMetadata) {
         return [];
@@ -34,9 +35,10 @@ export function useBarChartPlotDataParser() {
         valueType === 'gene' ? segmentationMetadata.geneNames : segmentationMetadata.proteinNames
       ).findIndex((name) => name === selectedvalue);
 
+      const orderedRois = sortRois ? [...rois].sort((a, b) => a - b) : rois;
       const cellsByRoiId = new Map(selectedCells.map((sel) => [sel.roiId, sel]));
-      const validSelection = rois
-        ? rois.map((roiId) => cellsByRoiId.get(roiId)).filter((sel) => sel !== undefined)
+      const validSelection = orderedRois
+        ? orderedRois.map((roiId) => cellsByRoiId.get(roiId)).filter((sel) => sel !== undefined)
         : [];
       const parsedColormap = cellColormapConfig.reduce(
         (acc, item) => {
@@ -150,7 +152,7 @@ export function useBarChartPlotDataParser() {
         }
 
         // Convert to plot data entries with mean values
-        return rois
+        return orderedRois
           .filter((roiId) => aggregatedData.has(roiId.toString()))
           .map((roiId) => {
             const clusterMap = aggregatedData.get(roiId.toString())!;

--- a/src/components/DashboardCharts/BarChart/sections/BarChartPlot/BarChartPlot.tsx
+++ b/src/components/DashboardCharts/BarChart/sections/BarChartPlot/BarChartPlot.tsx
@@ -18,8 +18,16 @@ export const BarChartPlot = ({
   const { parseCellsByRoi } = useBarChartPlotDataParser();
 
   const barPlotData = useMemo(
-    () => parseCellsByRoi(selectedROIs, selectedValueType, selectedValue, selectedHue, settings.swapAxis ? 'h' : 'v'),
-    [parseCellsByRoi, selectedValue, selectedROIs, selectedValueType, selectedHue, settings.swapAxis]
+    () =>
+      parseCellsByRoi(
+        selectedROIs,
+        selectedValueType,
+        selectedValue,
+        selectedHue,
+        settings.swapAxis ? 'h' : 'v',
+        settings.sortRois
+      ),
+    [parseCellsByRoi, selectedValue, selectedROIs, selectedValueType, selectedHue, settings.swapAxis, settings.sortRois]
   );
 
   useEffect(() => {

--- a/src/components/DashboardCharts/BarChart/sections/BarChartSettings/BarChartSettings.tsx
+++ b/src/components/DashboardCharts/BarChart/sections/BarChartSettings/BarChartSettings.tsx
@@ -60,6 +60,25 @@ export const BarChartSettings = ({ settings, onChangeSettings }: BarChartSetting
             }
           />
         </Grid>
+        {/* Sort ROIs  */}
+        <Grid
+          size={1}
+          alignContent={'center'}
+          sx={sx.settingLabel}
+        >
+          <Typography>{t('dashboard.plotSortRoisLabel')}:</Typography>
+        </Grid>
+        <Grid size={1}>
+          <GxCheckbox
+            value={settings.sortRois}
+            onChange={() =>
+              onChangeSettings({
+                ...settings,
+                sortRois: !settings.sortRois
+              })
+            }
+          />
+        </Grid>
         {/* Bar mode  */}
         <Grid
           size={1}

--- a/src/components/DashboardCharts/BarChart/sections/BarChartSettings/BarChartSettings.types.ts
+++ b/src/components/DashboardCharts/BarChart/sections/BarChartSettings/BarChartSettings.types.ts
@@ -7,6 +7,7 @@ export type BarChartSettingOptions = {
   swapAxis: boolean;
   barMode: BarChartBarMode;
   customTitle?: string;
+  sortRois: boolean;
 };
 
 export type BarChartBarMode = 'group' | 'stack' | 'relative' | 'overlay';

--- a/src/components/DashboardCharts/BoxChart/BoxChart.tsx
+++ b/src/components/DashboardCharts/BoxChart/BoxChart.tsx
@@ -17,7 +17,8 @@ export const BoxChart = ({ id, title, removable = true }: BoxChartProps) => {
   const [selectedValueType, setSelectedValueType] = useState<BoxChartValueType>('protein');
   const [settings, setSettings] = useState<BoxChartSettingOptions>({
     swapAxis: false,
-    dataMode: 'suspectedoutliers'
+    dataMode: 'suspectedoutliers',
+    sortRois: false
   });
 
   return (

--- a/src/components/DashboardCharts/BoxChart/sections/BoxChartPlot/BoxChartPlot.helpers.ts
+++ b/src/components/DashboardCharts/BoxChart/sections/BoxChartPlot/BoxChartPlot.helpers.ts
@@ -26,7 +26,8 @@ export function useBoxChartPlotDataParser() {
       selectedvalue: string,
       hueValue: BoxChartHueValueOptions,
       orientation: BoxChartOrientation,
-      dataMode: BoxChartDataMode
+      dataMode: BoxChartDataMode,
+      sortRois: boolean
     ): BoxChartDataEntry[] => {
       if (!selectedCells.length || !segmentationMetadata) {
         return [];
@@ -36,9 +37,10 @@ export function useBoxChartPlotDataParser() {
         valueType === 'gene' ? segmentationMetadata.geneNames : segmentationMetadata.proteinNames
       ).findIndex((name) => name === selectedvalue);
 
+      const orderedRois = sortRois ? [...rois].sort((a, b) => a - b) : rois;
       const cellsByRoiId = new Map(selectedCells.map((sel) => [sel.roiId, sel]));
-      const validSelection = rois
-        ? rois.map((roiId) => cellsByRoiId.get(roiId)).filter((sel) => sel !== undefined)
+      const validSelection = orderedRois
+        ? orderedRois.map((roiId) => cellsByRoiId.get(roiId)).filter((sel) => sel !== undefined)
         : [];
       const parsedColormap = cellColormapConfig.reduce(
         (acc, item) => {
@@ -101,7 +103,7 @@ export function useBoxChartPlotDataParser() {
         }
 
         // Convert to plot data entries
-        return rois
+        return orderedRois
           .filter((roiId) => roiData.has(roiId.toString()))
           .map((roiId) => {
             const data = roiData.get(roiId.toString())!;

--- a/src/components/DashboardCharts/BoxChart/sections/BoxChartPlot/BoxChartPlot.tsx
+++ b/src/components/DashboardCharts/BoxChart/sections/BoxChartPlot/BoxChartPlot.tsx
@@ -25,9 +25,19 @@ export const BoxChartPlot = ({
         selectedValue,
         selectedHue,
         settings.swapAxis ? 'h' : 'v',
-        settings.dataMode
+        settings.dataMode,
+        settings.sortRois
       ),
-    [parseCellsByRoi, selectedValue, selectedROIs, selectedValueType, selectedHue, settings.swapAxis, settings.dataMode]
+    [
+      parseCellsByRoi,
+      selectedValue,
+      selectedROIs,
+      selectedValueType,
+      selectedHue,
+      settings.swapAxis,
+      settings.dataMode,
+      settings.sortRois
+    ]
   );
 
   useEffect(() => {

--- a/src/components/DashboardCharts/BoxChart/sections/BoxChartSettings/BoxChartSettings.tsx
+++ b/src/components/DashboardCharts/BoxChart/sections/BoxChartSettings/BoxChartSettings.tsx
@@ -60,6 +60,25 @@ export const BoxChartSettings = ({ settings, onChangeSettings }: BoxChartSetting
             }
           />
         </Grid>
+        {/* Sort ROIs  */}
+        <Grid
+          size={1}
+          alignContent={'center'}
+          sx={sx.settingLabel}
+        >
+          <Typography>{t('dashboard.plotSortRoisLabel')}:</Typography>
+        </Grid>
+        <Grid size={1}>
+          <GxCheckbox
+            value={settings.sortRois}
+            onChange={() =>
+              onChangeSettings({
+                ...settings,
+                sortRois: !settings.sortRois
+              })
+            }
+          />
+        </Grid>
         {/* Box point type  */}
         <Grid
           size={1}

--- a/src/components/DashboardCharts/BoxChart/sections/BoxChartSettings/BoxChartSettings.types.ts
+++ b/src/components/DashboardCharts/BoxChart/sections/BoxChartSettings/BoxChartSettings.types.ts
@@ -7,6 +7,7 @@ export type BoxChartSettingOptions = {
   swapAxis: boolean;
   dataMode: BoxChartDataMode;
   customTitle?: string;
+  sortRois: boolean;
 };
 
 export type BoxChartDataMode = 'all' | 'outliers' | 'suspectedoutliers' | 'none';

--- a/src/components/DashboardCharts/HeatmapChart/HeatmapChart.tsx
+++ b/src/components/DashboardCharts/HeatmapChart/HeatmapChart.tsx
@@ -12,7 +12,8 @@ export const HeatmapChart = ({ id, title, removable = true }: HeatmapChartProps)
   const [selectedValueType, setSelectedValueType] = useState<HeatmapChartValueType>('protein');
   const [settings, setSettings] = useState<HeatmapChartSettingOptions>({
     colorscale: { ...AVAILABLE_COLORSCALES[0], reversed: false },
-    normalization: 'none'
+    normalization: 'none',
+    sortRois: false
   });
 
   return (

--- a/src/components/DashboardCharts/HeatmapChart/sections/HeatmapChartPlot/HeatmapChartPlot.helpers.ts
+++ b/src/components/DashboardCharts/HeatmapChart/sections/HeatmapChartPlot/HeatmapChartPlot.helpers.ts
@@ -103,9 +103,10 @@ export function useHeatmapChartPlotDataParser() {
         return [];
       }
 
+      const orderedRois = settings.sortRois ? [...rois].sort((a, b) => a - b) : rois;
       const cellsByRoiId = new Map(selectedCells.map((sel) => [sel.roiId, sel]));
-      const validSelection = rois.length
-        ? rois.map((roiId) => cellsByRoiId.get(roiId)).filter((sel) => sel !== undefined)
+      const validSelection = orderedRois.length
+        ? orderedRois.map((roiId) => cellsByRoiId.get(roiId)).filter((sel) => sel !== undefined)
         : [];
 
       if (!validSelection.length) {
@@ -149,7 +150,7 @@ export function useHeatmapChartPlotDataParser() {
         }
 
         // Build heatmap matrix: rows = proteins/genes, cols = ROIs
-        const orderedRoiIds = rois.map(String).filter((id) => roiIds.has(id));
+        const orderedRoiIds = orderedRois.map(String).filter((id) => roiIds.has(id));
         const sortedValueNames = Array.from(valueNamesSet);
 
         let zMatrix: number[][] = [];

--- a/src/components/DashboardCharts/HeatmapChart/sections/HeatmapChartSettings/HeatmapChartSettings.tsx
+++ b/src/components/DashboardCharts/HeatmapChart/sections/HeatmapChartSettings/HeatmapChartSettings.tsx
@@ -129,6 +129,25 @@ export const HeatmapChartSettings = ({ settings, onChangeSettings }: HeatmapChar
             onClick={onReverseColorscale}
           />
         </Grid>
+        {/* Sort ROIs  */}
+        <Grid
+          size={1}
+          alignContent={'center'}
+          sx={sx.settingLabel}
+        >
+          <Typography>{t('dashboard.plotSortRoisLabel')}:</Typography>
+        </Grid>
+        <Grid size={1}>
+          <GxCheckbox
+            value={settings.sortRois}
+            onChange={() =>
+              onChangeSettings({
+                ...settings,
+                sortRois: !settings.sortRois
+              })
+            }
+          />
+        </Grid>
         {/* Normalization option */}
         <Grid
           alignContent={'center'}

--- a/src/components/DashboardCharts/HeatmapChart/sections/HeatmapChartSettings/HeatmapChartSettings.types.ts
+++ b/src/components/DashboardCharts/HeatmapChart/sections/HeatmapChartSettings/HeatmapChartSettings.types.ts
@@ -14,6 +14,7 @@ export type HeatmapChartSettingOptions = {
   customTitle?: string;
   normalization?: HeatmapChartNormalizationOption;
   normalizationAxis?: HeatmapChartNormalizationAxisOption;
+  sortRois: boolean;
 };
 
 export type HeatmapChartNormalizationOption = 'none' | 'min-max' | 'z-score';

--- a/src/components/DashboardCharts/PieChart/PieChart.tsx
+++ b/src/components/DashboardCharts/PieChart/PieChart.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react';
 import { PieChartProps } from './PieChart.types';
 import { GxDashboardGraphWindow } from '../../../shared/components/GxDashboardGraphWindow';
-import { PieChartControls, PieChartPlot } from './sections';
+import { PieChartControls, PieChartPlot, PieChartSettings, PieChartSettingOptions } from './sections';
 
 export const PieChart = ({ id, title, removable = true }: PieChartProps) => {
   const [selectedROIs, setSelectedROIs] = useState<number[]>([]);
+  const [settings, setSettings] = useState<PieChartSettingOptions>({
+    sortRois: false
+  });
 
   return (
     <GxDashboardGraphWindow
@@ -17,7 +20,18 @@ export const PieChart = ({ id, title, removable = true }: PieChartProps) => {
           onRoiChange={setSelectedROIs}
         />
       }
-      graphContent={<PieChartPlot selectedRois={selectedROIs} />}
+      settingsContent={
+        <PieChartSettings
+          settings={settings}
+          onChangeSettings={setSettings}
+        />
+      }
+      graphContent={
+        <PieChartPlot
+          selectedRois={selectedROIs}
+          settings={settings}
+        />
+      }
     />
   );
 };

--- a/src/components/DashboardCharts/PieChart/sections/PieChartPlot/PieChartPlot.tsx
+++ b/src/components/DashboardCharts/PieChart/sections/PieChartPlot/PieChartPlot.tsx
@@ -17,7 +17,7 @@ const buildHoverTemplate = (clusterIdLabel: string, countLabel: string, percentL
   return `<b>${clusterIdLabel}: %{label}</b><br>${countLabel}: %{value}<br>${percentLabel}: %{percent}<extra></extra>`;
 };
 
-export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
+export const PieChartPlot = ({ selectedRois, settings }: PieChartPlotProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -26,6 +26,8 @@ export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
   const [selectedCells, colorMapConfig] = useCellSegmentationLayerStore(
     useShallow((store) => [store.selectedCells, store.cellColormapConfig])
   );
+
+  const orderedRois = settings.sortRois ? [...selectedRois].sort((a, b) => a - b) : selectedRois;
 
   useEffect(() => {
     const containerEl = containerRef.current;
@@ -58,7 +60,7 @@ export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
       t('pieChart.hoverPercent')
     );
     const pieData: Partial<Data>[] = [];
-    const numRois = selectedRois.length;
+    const numRois = orderedRois.length;
 
     const minPieSize = 300;
     const cols = Math.max(1, Math.floor(dimensions.width / minPieSize));
@@ -70,13 +72,13 @@ export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
     const actualCols = numRois < cols ? numRois : cols;
     const offset = (cols - actualCols) / (2 * cols);
 
-    let roiWithMostClusters = selectedRois[0];
+    let roiWithMostClusters = orderedRois[0];
     let maxClusterCount = 0;
 
     const cellsByRoiId = new Map(selectedCells.map((sel) => [sel.roiId, sel]));
 
     let roiIndex = 0;
-    for (const roiId of selectedRois) {
+    for (const roiId of orderedRois) {
       const selection = cellsByRoiId.get(roiId);
       if (!selection) continue;
 
@@ -132,11 +134,11 @@ export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
     }
 
     return pieData;
-  }, [selectedCells, selectedRois, colorMapConfig, theme.palette.gx.mediumGrey, dimensions.width, t]);
+  }, [selectedCells, orderedRois, colorMapConfig, theme.palette.gx.mediumGrey, dimensions.width, t]);
 
   const layout: Partial<Layout> = useMemo(() => {
     const annotations: any[] = [];
-    const numRois = selectedRois.length;
+    const numRois = orderedRois.length;
     const minPieSize = 300;
     const cols = Math.max(1, Math.floor(dimensions.width / minPieSize));
     const rows = Math.ceil(numRois / cols);
@@ -146,7 +148,7 @@ export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
     const actualCols = numRois < cols ? numRois : cols;
     const offset = (cols - actualCols) / (2 * cols);
 
-    selectedRois.forEach((roiId, roiIndex) => {
+    orderedRois.forEach((roiId, roiIndex) => {
       const col = roiIndex % cols;
       const row = Math.floor(roiIndex / cols);
 
@@ -188,7 +190,7 @@ export const PieChartPlot = ({ selectedRois }: PieChartPlotProps) => {
       },
       annotations: annotations
     };
-  }, [dimensions.width, dimensions.height, selectedRois, t]);
+  }, [dimensions.width, dimensions.height, orderedRois, t]);
 
   return (
     <Box

--- a/src/components/DashboardCharts/PieChart/sections/PieChartPlot/PieChartPlot.types.ts
+++ b/src/components/DashboardCharts/PieChart/sections/PieChartPlot/PieChartPlot.types.ts
@@ -1,3 +1,6 @@
+import { PieChartSettingOptions } from '../PieChartSettings/PieChartSettings.types';
+
 export type PieChartPlotProps = {
   selectedRois: number[];
+  settings: PieChartSettingOptions;
 };

--- a/src/components/DashboardCharts/PieChart/sections/PieChartSettings/PieChartSettings.tsx
+++ b/src/components/DashboardCharts/PieChart/sections/PieChartSettings/PieChartSettings.tsx
@@ -1,0 +1,55 @@
+import { Box, Grid, SxProps, Theme, Typography, useTheme } from '@mui/material';
+import { GxCheckbox } from '../../../../../shared/components/GxCheckbox';
+import { PieChartSettingsProps } from './PieChartSettings.types';
+import { useTranslation } from 'react-i18next';
+
+export const PieChartSettings = ({ settings, onChangeSettings }: PieChartSettingsProps) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const sx = styles(theme);
+
+  return (
+    <Box>
+      <Grid
+        container
+        columns={2}
+        columnSpacing={1}
+        rowSpacing={1}
+        sx={sx.container}
+      >
+        {/* Sort ROIs  */}
+        <Grid
+          size={1}
+          alignContent={'center'}
+          sx={sx.settingLabel}
+        >
+          <Typography>{t('dashboard.plotSortRoisLabel')}:</Typography>
+        </Grid>
+        <Grid size={1}>
+          <GxCheckbox
+            value={settings.sortRois}
+            onChange={() =>
+              onChangeSettings({
+                ...settings,
+                sortRois: !settings.sortRois
+              })
+            }
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+const styles = (theme: Theme): Record<string, SxProps> => ({
+  container: {
+    width: '350px'
+  },
+  settingLabel: {
+    borderRight: '2px solid',
+    borderColor: theme.palette.gx.mediumGrey[500],
+    textWrap: 'nowrap',
+    textAlign: 'end',
+    paddingInlineEnd: '8px'
+  }
+});

--- a/src/components/DashboardCharts/PieChart/sections/PieChartSettings/PieChartSettings.types.ts
+++ b/src/components/DashboardCharts/PieChart/sections/PieChartSettings/PieChartSettings.types.ts
@@ -1,0 +1,8 @@
+export type PieChartSettingsProps = {
+  settings: PieChartSettingOptions;
+  onChangeSettings: (newSettings: PieChartSettingOptions) => void;
+};
+
+export type PieChartSettingOptions = {
+  sortRois: boolean;
+};

--- a/src/components/DashboardCharts/PieChart/sections/PieChartSettings/index.ts
+++ b/src/components/DashboardCharts/PieChart/sections/PieChartSettings/index.ts
@@ -1,0 +1,2 @@
+export { PieChartSettings } from './PieChartSettings';
+export type { PieChartSettingOptions, PieChartSettingsProps } from './PieChartSettings.types';

--- a/src/components/DashboardCharts/PieChart/sections/index.ts
+++ b/src/components/DashboardCharts/PieChart/sections/index.ts
@@ -1,2 +1,3 @@
 export * from './PieChartControls';
 export * from './PieChartPlot';
+export * from './PieChartSettings';


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Slack feedback

## Description

- Preserved user selected ROI order in dashboard charts
- Added option in the settings to sort ROIs

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Open app
2. Select ROIs and add them to chart
