### PR TITLE
Feat/block HE images in main upload

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -178,6 +178,7 @@
     "imageInvalidFile": "Invalid input file name. Only .ome.tiff and .zarr extensions allowed",
     "imageSuccess": "Successfully loaded image from URL: {{filename}}",
     "imageUploadButton": "Upload Image File",
+    "heImageNotSupported": "H&E images are not supported here. Please upload H&E images in Brightfield Images Settings section instead.",
     "metadataInputLabel": "Metadata File",
     "metadataInvalidFile": "Invalid file format. Only .json files are allowed",
     "metadataInvalidJsonError": "Error loading Run Metadata file. The file contains invalid values. Please check your file.",

--- a/src/hooks/useProteinImage.hook.ts
+++ b/src/hooks/useProteinImage.hook.ts
@@ -72,7 +72,6 @@ export const useProteinImage = (source: ViewerSourceType | null) => {
             variant: 'error',
             autoHideDuration: 5000
           });
-          // Restore the last valid source
           useViewerStore.setState({
             source: lastValidSourceRef.current,
             isViewerLoading: undefined,
@@ -83,7 +82,6 @@ export const useProteinImage = (source: ViewerSourceType | null) => {
       }
 
       if (nextLoader) {
-        // Store this source as the last valid one after successful validation
         lastValidSourceRef.current = source;
 
         unstable_batchedUpdates(() => {


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #63 

## Description

Blocked HE images in main upload.

We check whether the image is RGB and has only one channel.

Differences we found:

**Main ome tiff**
```
{
  isRgb: false,
  isInterleaved: false,
  shape: [1, 1, 22, 19200, 15232], 
  channels: 22,
  type: "uint16",
  SamplesPerPixel: 1
}
```
**HE**
```
{
  isRgb: true,
  isInterleaved: true,
  shape: [1, 1, 3, 19200, 15232, 3], 
  channels: 1,
  type: "uint8",
  SamplesPerPixel: 3
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Open app
2. Try to load HE image in the main image upload
