### PR TITLE
Feat/Overview - H&E Image Layer Visibility

### DIFF
--- a/src/components/PictureInPictureViewer/PictureInPictureViewer.tsx
+++ b/src/components/PictureInPictureViewer/PictureInPictureViewer.tsx
@@ -3,6 +3,8 @@ import { DETAIL_VIEW_ID, OVERVIEW_VIEW_ID, OverviewView, getDefaultInitialViewSt
 import * as React from 'react';
 import { PictureInPictureViewerProps } from './PictureInPictureViewer.types';
 import DetailView from '../DetailView';
+import { useBrightfieldImagesStore } from '../../stores/BrightfieldImagesStore';
+import { useShallow } from 'zustand/react/shallow';
 
 export default function PictureInPictureViewer(props: PictureInPictureViewerProps) {
   const {
@@ -32,6 +34,23 @@ export default function PictureInPictureViewer(props: PictureInPictureViewerProp
     extensions = [new ColorPaletteExtension()],
     deckProps
   } = props;
+  const [
+    brightfieldImageSource,
+    isBrightfieldLayerVisible,
+    getBrightfieldLoader,
+    brightfieldContrastLimits,
+    brightfieldColors,
+    brightfieldSelections
+  ] = useBrightfieldImagesStore(
+    useShallow((store) => [
+      store.brightfieldImageSource,
+      store.isLayerVisible,
+      store.getLoader,
+      store.contrastLimits,
+      store.colors,
+      store.selections
+    ])
+  );
 
   const detailViewState = viewStatesProp?.find((v) => v.id === DETAIL_VIEW_ID);
   // biome-ignore lint/correctness/useExhaustiveDependencies: Carried over from eslint, without explanation.
@@ -67,8 +86,18 @@ export default function PictureInPictureViewer(props: PictureInPictureViewerProp
   const views = [detailView];
   const layerProps = [layerConfig];
   const viewStates = [{ ...baseViewState, id: DETAIL_VIEW_ID }];
+  const overviewSource =
+    brightfieldImageSource && isBrightfieldLayerVisible
+      ? {
+          loader: getBrightfieldLoader(),
+          contrastLimits: brightfieldContrastLimits as [number, number][],
+          colors: brightfieldColors,
+          channelsVisible: Array(brightfieldColors.length).fill(true),
+          selections: brightfieldSelections
+        }
+      : { loader, contrastLimits, colors, channelsVisible, selections };
 
-  if (overviewOn && loader) {
+  if (overviewOn && overviewSource.loader) {
     // It's unclear why this is needed because OverviewView.filterViewState sets "zoom" and "target".
     const overviewViewState = viewStatesProp?.find((v) => v.id === OVERVIEW_VIEW_ID) || {
       ...baseViewState,
@@ -77,7 +106,7 @@ export default function PictureInPictureViewer(props: PictureInPictureViewerProp
 
     const overviewView = new OverviewView({
       id: OVERVIEW_VIEW_ID,
-      loader,
+      loader: overviewSource.loader,
       detailHeight: height,
       detailWidth: width,
       clickCenter,
@@ -85,7 +114,11 @@ export default function PictureInPictureViewer(props: PictureInPictureViewerProp
     } as any);
 
     views.push(overviewView as any);
-    layerProps.push({ ...layerConfig, lensEnabled: false });
+    layerProps.push({
+      ...layerConfig,
+      ...overviewSource,
+      lensEnabled: false
+    });
     viewStates.push(overviewViewState as any);
   }
 


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #202

## Description

Updated overview rendering to use the H&E image source and settings when the brightfield layer is enabled

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Open app and load Zarr
2. Toggle the H&E image and check the overview.
