### PR TITLE
Fix/Auto enable gene name filter toggle on apply

### DIFF
--- a/src/components/ViewController/TranscriptLayerSection/PointsFilter/PointFiltersTable/PointFiltersTable.tsx
+++ b/src/components/ViewController/TranscriptLayerSection/PointsFilter/PointFiltersTable/PointFiltersTable.tsx
@@ -40,6 +40,9 @@ export const PointFiltersTable = () => {
 
   const handleApplyClick = () => {
     setGeneNamesFilter(activeFilters);
+    if (!isGeneNameFilterActive && activeFilters.length > 0) {
+      useTranscriptLayerStore.getState().toggleGeneNameFilter();
+    }
   };
 
   const haveFiltersChanges =
@@ -54,7 +57,7 @@ export const PointFiltersTable = () => {
       onApplyClick={handleApplyClick}
       onSetFilter={(filters) => setActiveFilters(filters)}
       clearDisabled={!isGeneNameFilterActive || activeFilters.length === 0}
-      applyDisabled={!isGeneNameFilterActive || activeFilters.length === 0 || !haveFiltersChanges}
+      applyDisabled={activeFilters.length === 0 || !haveFiltersChanges}
     />
   );
 };


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #[number]

## Description

Auto enable gene name filter toggle on apply in the Transcript Points Filter to match the Cell Segmentation Filter behavior.

<img width="702" height="816" alt="image" src="https://github.com/user-attachments/assets/dd70cd87-7fec-4fec-a750-0d559f892d28" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Open app 
2. Select tx gene name and click apply
