### PR TITLE
Feat/Cell centroids for ROI detection

### DIFF
--- a/src/components/PictureInPictureViewerAdapter/worker/polygonDetectionWorker.ts
+++ b/src/components/PictureInPictureViewerAdapter/worker/polygonDetectionWorker.ts
@@ -12,9 +12,7 @@ import { LayerConfig } from '../../../stores/ZarrDataStore/ZarrDataStore.types';
 import { ZarrDataSet } from '../../../utils/ZarrDataSet';
 import {
   getPolygonBoundingBox,
-  isPointInSelection,
-  isPolygonInSelection,
-  isPolygonWithinBoundingBox
+  isPointInSelection
 } from '../../../stores/PolygonDrawingStore/PolygonDrawingStore.helpers';
 
 const getZarrIntersectingTileCoordinates = (
@@ -209,14 +207,8 @@ const detectCellPolygonsInPolygon = async (
   try {
     const cellPolygonsInDrawnPolygon: SingleMask[] = [];
     for (const cellMask of cellMasksData) {
-      if (cellMask.vertices) {
-        if (!isPolygonWithinBoundingBox(cellMask.vertices, polygonBoundingBox)) {
-          continue;
-        }
-
-        if (isPolygonInSelection(cellMask.vertices, polygon.geometry.coordinates[0], polygonBoundingBox)) {
-          cellPolygonsInDrawnPolygon.push(cellMask);
-        }
+      if (isPointInSelection(cellMask.centroid, polygon.geometry.coordinates[0], polygonBoundingBox)) {
+        cellPolygonsInDrawnPolygon.push(cellMask);
       }
     }
 

--- a/src/components/PolygonImportExport/PolygonImportExport.types.ts
+++ b/src/components/PolygonImportExport/PolygonImportExport.types.ts
@@ -10,7 +10,7 @@ export type CellsExportData = Record<
   string,
   {
     coordinates: [number, number][];
-    cells: Omit<SingleMask, 'nonzeroGeneIndices' | 'nonzeroGeneValues' | 'proteinValues'>[];
+    cells: Omit<SingleMask, 'nonzeroGeneIndices' | 'nonzeroGeneValues' | 'proteinValues' | 'centroid'>[];
     polygonId: number;
     notes?: string;
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@ export type UmapEntry = {
 
 export type SingleMask = {
   vertices: number[];
+  centroid: [number, number];
   area: number;
   totalCounts: number;
   totalGenes: number;

--- a/src/stores/PolygonDrawingStore/PolygonDrawingStore.helpers.ts
+++ b/src/stores/PolygonDrawingStore/PolygonDrawingStore.helpers.ts
@@ -149,16 +149,6 @@ export const isPointWitinBoundingBox = (point: [number, number], boundingBox: Bo
   );
 };
 
-// Check if polygon is fullt inside a rectangular bounding box
-export const isPolygonWithinBoundingBox = (cellVertices: number[], boundingBox: BoundingBox): boolean => {
-  for (let i = 0; i < cellVertices.length; i += 2) {
-    if (!isPointWitinBoundingBox([cellVertices[i], cellVertices[i + 1]], boundingBox)) {
-      return false;
-    }
-  }
-  return true;
-};
-
 // Ray Casting Algorithm with early exit optimization: Casts a horizontal ray from the point to infinity and counts edge intersections.
 // Odd count = inside, even count = outside.
 export const isPointInSelection = (point: [number, number], coordinates: number[][], boundingBox: BoundingBox) => {
@@ -179,22 +169,6 @@ export const isPointInSelection = (point: [number, number], coordinates: number[
     }
   }
   return inside;
-};
-
-export const isPolygonInSelection = (cellVertices: number[], coordinates: number[][], boundingBox: BoundingBox) => {
-  if (!cellVertices || cellVertices.length < 6) return false;
-
-  // Check each vertex of the cell polygon
-  for (let i = 0; i < cellVertices.length; i += 2) {
-    const x = cellVertices[i];
-    const y = cellVertices[i + 1];
-
-    if (!isPointInSelection([x, y], coordinates, boundingBox)) {
-      return false;
-    }
-  }
-
-  return true;
 };
 
 export const removeDuplicates = (points: any[]) => {

--- a/src/utils/ZarrCellsLoader.ts
+++ b/src/utils/ZarrCellsLoader.ts
@@ -61,6 +61,7 @@ async function loadCellsFromGroup(cellsGroup: any): Promise<ZarrCellsData> {
       totalCountsChunk,
       totalGenesChunk,
       umapChunk,
+      positionChunk,
       proteinNamesChunk
     ] = await Promise.all([
       openAndGet(cellsGroup.resolve(ZARR_CELL_FIELDS.cellId)),
@@ -72,6 +73,7 @@ async function loadCellsFromGroup(cellsGroup: any): Promise<ZarrCellsData> {
       openAndGet(cellsGroup.resolve(ZARR_CELL_FIELDS.totalCounts)),
       openAndGet(cellsGroup.resolve(ZARR_CELL_FIELDS.totalGenes)),
       openAndGet(cellsGroup.resolve(ZARR_CELL_FIELDS.umap)),
+      openAndGet(cellsGroup.resolve(ZARR_CELL_FIELDS.position)),
       openAndGet(cellsGroup.resolve(ZARR_CELL_FIELDS.proteinNames))
     ]);
 
@@ -92,6 +94,7 @@ async function loadCellsFromGroup(cellsGroup: any): Promise<ZarrCellsData> {
     const totalCounts = totalCountsChunk.data as Uint16Array;
     const totalGenes = totalGenesChunk.data as Uint16Array;
     const umapData = umapChunk.data as Float16Array;
+    const positionData = positionChunk.data as Float16Array;
 
     const proteinNames = extractStringArray(proteinNamesChunk);
     const geneNames = extractStringArray(geneNamesChunk);
@@ -147,6 +150,7 @@ async function loadCellsFromGroup(cellsGroup: any): Promise<ZarrCellsData> {
         area: areas[i],
         clusterId: getClusterId(i, defaultLabel.index),
         vertices,
+        centroid: [positionData[i * 2], positionData[i * 2 + 1]],
         proteinValues: proteinVals,
         totalCounts: totalCounts[i],
         totalGenes: totalGenes[i],

--- a/src/utils/ZarrPaths.ts
+++ b/src/utils/ZarrPaths.ts
@@ -43,6 +43,7 @@ export const ZARR_CELL_FIELDS = {
   totalCounts: 'total_counts',
   totalGenes: 'total_genes',
   umap: 'umap',
+  position: 'position', // cell centroid
   proteinNames: 'protein_names',
   geneNames: 'gene_names',
   geneCounts: 'gene_counts',


### PR DESCRIPTION
# Pull Request Template

## Issue

Ticket: Resolves #[number]

## Description

Cell detection in ROIs now uses centroids instead of full polygon containment

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (modifies existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How to Test

1. Open app
2. Select ROI area with cells
